### PR TITLE
RCAL-704 Update schema for resample usage

### DIFF
--- a/src/rad/resources/schemas/mosaic_basic-1.0.0.yaml
+++ b/src/rad/resources/schemas/mosaic_basic-1.0.0.yaml
@@ -168,5 +168,6 @@ propertyOrder: [ time_first_mjd, time_last_mjd, time_mean_mjd, max_exposure_time
 flowStyle: block
 required: [ time_first_mjd, time_last_mjd, time_mean_mjd, max_exposure_time,
             mean_exposure_time, model_type, visit, segment, pass, program,
-            survey, optical_element, instrument, telescope, location_name, product_type ]
+            survey, optical_element, instrument, telescope, location_name, product_type,
+            filename ]
 ...

--- a/src/rad/resources/schemas/mosaic_basic-1.0.0.yaml
+++ b/src/rad/resources/schemas/mosaic_basic-1.0.0.yaml
@@ -159,9 +159,12 @@ properties:
     archive_catalog:
       datatype: nvarchar(25)
       destination: [ScienceCommon.product_type]
+  filename:
+    tag: asdf://stsci.edu/datamodels/roman/tags/filename-1.0.0
 propertyOrder: [ time_first_mjd, time_last_mjd, time_mean_mjd, max_exposure_time,
                  mean_exposure_time, model_type, visit, segment, pass, program,
-                 survey, optical_element, instrument, telescope, location_name, product_type ]
+                 survey, optical_element, instrument, telescope, location_name, product_type,
+                 filename ]
 flowStyle: block
 required: [ time_first_mjd, time_last_mjd, time_mean_mjd, max_exposure_time,
             mean_exposure_time, model_type, visit, segment, pass, program,

--- a/src/rad/resources/schemas/wfi_mosaic-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_mosaic-1.0.0.yaml
@@ -15,8 +15,6 @@ properties:
     allOf:
       - type: object
         properties:
-          filename:
-            tag: asdf://stsci.edu/datamodels/roman/tags/filename-1.0.0
           # Placeholder for 'asn' schema tag
           # Placeholder for 'dither' schema tag
           basic:

--- a/src/rad/resources/schemas/wfi_mosaic-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_mosaic-1.0.0.yaml
@@ -30,7 +30,9 @@ properties:
             anyOf:
               - tag: tag:stsci.edu:gwcs/wcs-*
               - type: "null"
-        required: [basic, program, resample, wcs]
+          wcsinfo:
+            tag: asdf://stsci.edu/datamodels/roman/tags/mosaic_wcsinfo-1.0.0
+        required: [basic, program, resample, wcs, wcsinfo]
   data:
     title: Science data, excluding border reference pixels.
     tag: tag:stsci.edu:asdf/unit/quantity-1.1.0

--- a/src/rad/resources/schemas/wfi_mosaic-1.0.0.yaml
+++ b/src/rad/resources/schemas/wfi_mosaic-1.0.0.yaml
@@ -15,6 +15,8 @@ properties:
     allOf:
       - type: object
         properties:
+          filename:
+            tag: asdf://stsci.edu/datamodels/roman/tags/filename-1.0.0
           # Placeholder for 'asn' schema tag
           # Placeholder for 'dither' schema tag
           basic:


### PR DESCRIPTION
WIP [RCAL-704](https://jira.stsci.edu/browse/RCAL-704)

This PR modifies the L3 meta as follows:
- adds `filename` to the basic schema, due to current resample_step usage.
- adds `wcsinfo` to wfi_mosaic schema.

**Checklist**
- [ ] Schema changes discussed at RAD Review Board meeting
- [ ] Added entry in `CHANGES.rst` under the corresponding subsection
- [ ] Updated relevant roman_datamodels utilities and tests
- [ ] Passed romancal regression testing on Jenkins / PLWishMaster. Link: https://plwishmaster.stsci.edu:8081/job/RT/job/romancal/XXX/
